### PR TITLE
Update to latest CoffeeNet parent version 0.32.0

### DIFF
--- a/starter-discovery-example/pom.xml
+++ b/starter-discovery-example/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>coffee.synyx</groupId>
         <artifactId>coffeenet-starter-parent</artifactId>
-        <version>0.31.0</version>
+        <version>0.32.0</version>
         <relativePath/>
     </parent>
 

--- a/starter-logging-example/pom.xml
+++ b/starter-logging-example/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>coffee.synyx</groupId>
         <artifactId>coffeenet-starter-parent</artifactId>
-        <version>0.31.0</version>
+        <version>0.32.0</version>
     </parent>
 
     <repositories>

--- a/starter-navigation-javascript-example/pom.xml
+++ b/starter-navigation-javascript-example/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>coffee.synyx</groupId>
         <artifactId>coffeenet-starter-parent</artifactId>
-        <version>0.31.0</version>
+        <version>0.32.0</version>
     </parent>
 
     <repositories>

--- a/starter-navigation-thymeleaf-example/pom.xml
+++ b/starter-navigation-thymeleaf-example/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>coffee.synyx</groupId>
         <artifactId>coffeenet-starter-parent</artifactId>
-        <version>0.31.0</version>
+        <version>0.32.0</version>
     </parent>
 
     <repositories>

--- a/starter-security-example/pom.xml
+++ b/starter-security-example/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>coffee.synyx</groupId>
         <artifactId>coffeenet-starter-parent</artifactId>
-        <version>0.31.0</version>
+        <version>0.32.0</version>
     </parent>
 
     <repositories>


### PR DESCRIPTION
New CoffeeNet parent version 0.32.0 was released! Please check https://github.com/coffeenet/coffeenet-starter/blob/master/CHANGELOG.md for more information